### PR TITLE
Comment out 'lama' in MPS_UNSUPPORT_MODELS

### DIFF
--- a/sorawm/iopaint/const.py
+++ b/sorawm/iopaint/const.py
@@ -12,7 +12,7 @@ DIFFUSERS_SDXL_CLASS_NAME = "StableDiffusionXLPipeline"
 DIFFUSERS_SDXL_INPAINT_CLASS_NAME = "StableDiffusionXLInpaintPipeline"
 
 MPS_UNSUPPORT_MODELS = [
-    "lama",
+    # "lama",
     "ldm",
     "zits",
     "mat",


### PR DESCRIPTION
Comment out 'lama' in the unsupported models list. This will enable the mps support for this model.

#31 