### PR TITLE
fix(build): add missing axios dependency    

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "axios": "^1.13.2",
     "element-plus": "^2.11.8",
     "pinia": "^3.0.4",
     "vue": "^3.5.22"


### PR DESCRIPTION
Add axios to package.json to resolve build error:
  [vite]: Rollup failed to resolve import "axios"

  The code imports axios in src/App.vue:6 but the dependency
  was missing from package.json, causing production build failure.